### PR TITLE
Fix links to Twitter & GitHub

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -33,12 +33,12 @@ publishDir = "public"
 [[menu.footer]]
     identifier = "twitter"
     pre = "<i class='fa fa-twitter'></i>"
-    url = "https://twitter.com/cboettig"
+    url = "https://twitter.com/neurolibre"
     weight = 1
 [[menu.footer]]
     identifier = "github"
     pre = "<i class='fa fa-github'></i>"
-    url = "https://github.com/cboettig"
+    url = "https://github.com/neurolibre"
     weight = 2
 [[menu.footer]]
     identifier = "copyright"


### PR DESCRIPTION
Hello,

I discovered Neurolibre.com thanks to the Open Science Room of OHBM, this is a great work! :)

I noticed that links to Twitter & GitHub accounts were linked to cboettig (the designer of the theme you use).

I modified the config file hoping that it will fix this. BTW, the only mention remains:
```text
$ git grep -n "cboettig"
.gitmodules:3:  url = https://github.com/cboettig/hugo-now-ui.git
```
which I think should not be touched.

Best,
Alexandre